### PR TITLE
Add fn draw_text_at

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,6 +155,17 @@ impl FontTexture<'_> {
         fonts: &[Font],
         glyphs: &[GlyphPosition<Color>],
     ) -> Result<(), String> {
+        self.draw_text_at(canvas, fonts, glyphs, 0, 0)
+    }
+
+    pub fn draw_text_at<RT: RenderTarget>(
+        &mut self,
+        canvas: &mut Canvas<RT>,
+        fonts: &[Font],
+        glyphs: &[GlyphPosition<Color>],
+        offset_x: i32,
+        offset_y: i32,
+    ) -> Result<(), String> {
         struct RenderableGlyph {
             texture_rect: Rect,
             canvas_rect: Rect,
@@ -172,8 +183,8 @@ impl FontTexture<'_> {
             .filter(|glyph| glyph.width * glyph.height > 0)
         {
             let canvas_rect = Rect::new(
-                glyph.x as i32,
-                glyph.y as i32,
+                glyph.x as i32  + offset_x,
+                glyph.y as i32 + offset_y,
                 glyph.width as u32,
                 glyph.height as u32,
             );


### PR DESCRIPTION
Add a really helpful function to draw text at (x: i32, y:i32) offset. It was written by @realkudo but he does not seem to be active. All test passed